### PR TITLE
Hotfix: fix tests ex3

### DIFF
--- a/exercises/tests/Tasks/ex3_mu_pred_interval.R
+++ b/exercises/tests/Tasks/ex3_mu_pred_interval.R
@@ -10,7 +10,7 @@ test_that("mu_pred_interval()", {
   
   test1 <- c(13.3, 14.9, 14.8, 14.8)
   expect_equal(unname(mu_pred_interval(test1, 0.95)), c(11.7, 17.2), tol= 0.01, info = "Error: Incorrect result for  c(13.3, 14.9, 14.8, 14.8), (95%)")
-  expect_equal(unname(mu_pred_interval(1:10, 0.95)), c(-1.7, 12.7), tol= 0.01, info = "Error: Incorrect result for 1:10, (95%)", )
+  expect_equal(unname(mu_pred_interval(1:10, 0.95)), c(-1.7, 12.7), tol= 0.01, info = "Error: Incorrect result for 1:10, (95%)")
   expect_equal(unname(mu_pred_interval(1:10, 0.8)), c(1.1, 9.9), tol= 0.01, info = "Error: Incorrect result for 1:10, (80%)")
 })
 

--- a/exercises/tests/Tasks/ex3_por_interval.R
+++ b/exercises/tests/Tasks/ex3_por_interval.R
@@ -6,8 +6,8 @@ test_that("posterior_odds_ratio_interval()", {
   #-----------------------------------------------------------------------------------
   # test for posterior_odds_ratio_interval()
   #-----------------------------------------------------------------------------------
-  expect_true(exists("mu_pred_point_est"),
-              info = "Error: mu_pred_point_est() is missing")
+  expect_true(exists("posterior_odds_ratio_interval"),
+              info = "Error: posterior_odds_ratio_interval() is missing")
   set.seed(4711)
   p0 <- rbeta(100000, 5, 95)
   p1 <- rbeta(100000, 10, 90)
@@ -18,9 +18,9 @@ test_that("posterior_odds_ratio_interval()", {
   set.seed(4711)
   p0 <- rbeta(100000, 5, 5)
   p1 <- rbeta(100000, 6, 5)
-  expect_equal(unname(posterior_odds_ratio_interval(p0, p1), 0.9), c(0.2714472, 5.5970131), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 5), p1 = rbeta(100000, 5, 6) and 90%.")
-  expect_equal(unname(posterior_odds_ratio_interval(p1, p0), 0.9), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 90%.")
-  expect_equal(unname(posterior_odds_ratio_interval(p1, p0), 0.8), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 80%.")  
+  expect_equal(unname(posterior_odds_ratio_interval(p0, p1, 0.9)), c(0.2714472, 5.5970131), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 5), p1 = rbeta(100000, 5, 6) and 90%.")
+  expect_equal(unname(posterior_odds_ratio_interval(p1, p0, 0.9)), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 90%.")
+  expect_equal(unname(posterior_odds_ratio_interval(p1, p0, 0.8)), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 80%.")  
 })
 
 

--- a/exercises/tests/Tasks/ex3_por_interval.R
+++ b/exercises/tests/Tasks/ex3_por_interval.R
@@ -20,7 +20,7 @@ test_that("posterior_odds_ratio_interval()", {
   p1 <- rbeta(100000, 6, 5)
   expect_equal(unname(posterior_odds_ratio_interval(p0, p1, 0.9)), c(0.2714472, 5.5970131), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 5), p1 = rbeta(100000, 5, 6) and 90%.")
   expect_equal(unname(posterior_odds_ratio_interval(p1, p0, 0.9)), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 90%.")
-  expect_equal(unname(posterior_odds_ratio_interval(p1, p0, 0.8)), c(0.1786667, 3.6839583), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 80%.")  
+  expect_equal(unname(posterior_odds_ratio_interval(p1, p0, 0.8)), c(0.252972, 2.633517), tol= 0.01, info = "Error: Incorrect result for p0 = rbeta(100000, 5, 6), p1 = rbeta(100000, 5, 5) and 80%.")  
 })
 
 


### PR DESCRIPTION
Given that the students are currently taking on this exercises we should merge this as a hot fix.

The most important change are on ex3_por_interval, because the second batch of test cases would fail, we close the bracket one argument early.