### PR TITLE
Change Sweave() to knit(), as syntax highlighting was not appearing

### DIFF
--- a/assignments/makefile
+++ b/assignments/makefile
@@ -7,7 +7,7 @@ TARGETPDF = $(SOURCESRNW:%.Rnw=%.pdf)
 	pdflatex $<; /bin/rm assignment*.tex assignment*.aux assignment*.log assignment*.out
 
 %.tex: %.Rnw
-	Rscript -e 'Sweave("$<")'
+	Rscript -e 'knitr::knit("$<")'
 
 %.html: %.md
 	Rscript -e 'rmarkdown::render("$<")'


### PR DESCRIPTION
I noticed when trying the makefile that the syntax highlighting was not appearing in the pdfs. Changing Sweave() to knitr::knit() fixed this for me. I don't know of any downsides of using knitr with .Rnw files, but if there are just ignore this pull request.