### PR TITLE
Add project work info

### DIFF
--- a/project.Rmd
+++ b/project.Rmd
@@ -5,17 +5,99 @@ date: "Page updated: `r format.Date(file.mtime('project.Rmd'),'%Y-%m-%d')`"
 
 ## Project work details
 
-Project work is done in groups of 1-3 persons. Preferred group size is
-2. Groups of 1-2 persons are assumed to do same amount of work per
-group. Group of 3 persons is assumed to do 50\% more work.
+Project work involves choosing a data set and performing a whole analysis
+according to all the elements studied along the course. It is done in groups of
+1-3 persons. Preferred group size is 2. Groups of 1-2 persons are assumed to do
+same amount of work per group. Group of 3 persons is assumed to do 50\% more
+work.
 
 The groups will get help for the project work in TA sessions. When
 there are no weekly assignments, the TA sessions are still organized
 for helping in the project work.
 
-The project work consist of
+The project work's evaluation consists of
 
- - peergraded project report
- - presentation and oral exam graded by the course staff
+ - peergraded project report,
+ - presentation and oral exam graded by the course staff.
 
-More info coming soon.
+The project report must include:
+
+  - description of the data and the analysis problem,
+  - description of at least two models, for example:
+    - non hierarchical and hierarchical,
+    - linear and non linear,
+    - variable selection with many models,
+  - informative or weakly informative priors, and justification of their
+    choices,
+  - Stan code (=brms= can be used but stan code needs to be present and
+    explained),
+  - how to run the Stan model,
+  - convergence diagnostics (Rhat, ESS, divergences),
+  - posterior predictive checks,
+  - model comparison (e.g. with loo),
+  - predictive performance assessment if applicable (e.g. classification
+    accuracy),
+  - sensitivity analysis with respect to prior choices,
+  - discussion of issues and potential improvements.
+  
+In addition to the submitted report, each project must be presented by the
+authoring group, according to the following guidelines:
+
+  - The presentation should be high level but sufficiently detailed information
+    should be readily available to help answering questions from the audience,
+  - the duration of the presentation should be 10 minutes (for 1-2 people
+    groups) or 15 minutes (3 people groups),
+  - at the end of the presentation there will be an extra 5-10 minutes of
+    questions by anyone in the audience or two attending TAs,
+  - grading will be done by the two TAs using standardized grading instructions,
+  - presenter's ID cards will be checked in order to ensure that the right
+    group is presenting.
+    
+Specific recommendations for the presentations include:
+
+  - The first slide should include project's title and group members' names,
+  - the chosen statistical model(s), including likelihood and priors, must be
+    explained and justified (you are *not* holding a presentation for a
+    hypothetical customer that does not care about the details),
+  - Make sure the font is big enough to be easily readable by the audience (this
+    includes figure captions, legends and axis information!),
+  - the grade will be reduced by one if the last slide does not contain actual
+    information ("Thank you" or "Questions?" type of slides as final slides
+    should be avoided),
+  - in general, the best presentations are often given by teams that have
+    frequently attended TA sessions and gotten feedback, so we strongly
+    recommend attending these sessions.
+
+As some data sets have been overused for these particular goals, note that the
+following ones are forbidden in this work (more can be added to this list so
+make sure to check it regularly):
+
+  - Titanic (R data set),
+  - mtcars (R data set),
+  - baseball batting (used by Bob Carpenter's StanCon case study).
+
+Modelling requirements and instructions:
+  
+  - Every parameter needs to have an explicit proper prior. Improper flat priors
+    are not allowed.
+  - A hierarchical model is a model where the prior of certain parameter
+    contain other parameters that are also estimated in the model. For instance,
+    `b ~ normal(mu, sigma)`, `mu ~ normal(0, 1)`, `sigma ~ exponential(1)`.
+  - Do not impose hard constrains on a parameter unless they are natural to
+    them. `uniform(a, b)` should not be used for general parameters.
+  - Models should include covariates. Modelling the outcome without predictors
+    is likely too simple for this analysis.
+  - `brms` can be used, but the Stan code must be included, briefly commented,
+    and all priors need to be checked from the Stan code.
+    
+    
+For similar notebooks we refer the student to:
+
+  * BDA R demos https://github.com/avehtari/BDA_R_demos/tree/master/demos_rstan,
+  * BDA Python demos
+    https://github.com/avehtari/BDA_py_demos/tree/master/demos_pystan,
+  * Stan case studies http://mc-stan.org/users/documentation/case-studies.html,
+  * StanCon case studies
+    http://mc-stan.org/users/documentation/case-studies.html (some of these
+    notebooks are for a bigger projects, but reflect still the basic idea of a
+    notebook presentation).

--- a/project.html
+++ b/project.html
@@ -13,6 +13,7 @@
 
 <title>Bayesian Data Analysis course - Project work</title>
 
+<script src="site_libs/header-attrs-2.3/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/readable.min.css" rel="stylesheet" />
@@ -378,21 +379,76 @@ div.tocify {
 
 
 <h1 class="title toc-ignore">Bayesian Data Analysis course - Project work</h1>
-<h4 class="date">Page updated: 2020-08-17</h4>
+<h4 class="date">Page updated: 2020-08-20</h4>
 
 </div>
 
 
 <div id="project-work-details" class="section level2">
 <h2>Project work details</h2>
-<p>Project work is done in groups of 1-3 persons. Preferred group size is 2. Groups of 1-2 persons are assumed to do same amount of work per group. Group of 3 persons is assumed to do 50% more work.</p>
+<p>Project work involves choosing a data set and performing a whole analysis according to all the elements studied along the course. It is done in groups of 1-3 persons. Preferred group size is 2. Groups of 1-2 persons are assumed to do same amount of work per group. Group of 3 persons is assumed to do 50% more work.</p>
 <p>The groups will get help for the project work in TA sessions. When there are no weekly assignments, the TA sessions are still organized for helping in the project work.</p>
-<p>The project work consist of</p>
+<p>The project work’s evaluation consists of</p>
 <ul>
-<li>peergraded project report</li>
-<li>presentation and oral exam graded by the course staff</li>
+<li>peergraded project report,</li>
+<li>presentation and oral exam graded by the course staff.</li>
 </ul>
-<p>More info coming soon.</p>
+<p>The project report must include:</p>
+<ul>
+<li>description of the data and the analysis problem,</li>
+<li>description of at least two models, for example:
+<ul>
+<li>non hierarchical and hierarchical,</li>
+<li>linear and non linear,</li>
+<li>variable selection with many models,</li>
+</ul></li>
+<li>informative or weakly informative priors, and justification of their choices,</li>
+<li>Stan code (=brms= can be used but stan code needs to be present and explained),</li>
+<li>how to run the Stan model,</li>
+<li>convergence diagnostics (Rhat, ESS, divergences),</li>
+<li>posterior predictive checks,</li>
+<li>model comparison (e.g. with loo),</li>
+<li>predictive performance assessment if applicable (e.g. classification accuracy),</li>
+<li>sensitivity analysis with respect to prior choices,</li>
+<li>discussion of issues and potential improvements.</li>
+</ul>
+<p>In addition to the submitted report, each project must be presented by the authoring group, according to the following guidelines:</p>
+<ul>
+<li>The presentation should be high level but sufficiently detailed information should be readily available to help answering questions from the audience,</li>
+<li>the duration of the presentation should be 10 minutes (for 1-2 people groups) or 15 minutes (3 people groups),</li>
+<li>at the end of the presentation there will be an extra 5-10 minutes of questions by anyone in the audience or two attending TAs,</li>
+<li>grading will be done by the two TAs using standardized grading instructions,</li>
+<li>presenter’s ID cards will be checked in order to ensure that the right group is presenting.</li>
+</ul>
+<p>Specific recommendations for the presentations include:</p>
+<ul>
+<li>The first slide should include project’s title and group members’ names,</li>
+<li>the chosen statistical model(s), including likelihood and priors, must be explained and justified (you are <em>not</em> holding a presentation for a hypothetical customer that does not care about the details),</li>
+<li>Make sure the font is big enough to be easily readable by the audience (this includes figure captions, legends and axis information!),</li>
+<li>the grade will be reduced by one if the last slide does not contain actual information (“Thank you” or “Questions?” type of slides as final slides should be avoided),</li>
+<li>in general, the best presentations are often given by teams that have frequently attended TA sessions and gotten feedback, so we strongly recommend attending these sessions.</li>
+</ul>
+<p>As some data sets have been overused for these particular goals, note that the following ones are forbidden in this work (more can be added to this list so make sure to check it regularly):</p>
+<ul>
+<li>Titanic (R data set),</li>
+<li>mtcars (R data set),</li>
+<li>baseball batting (used by Bob Carpenter’s StanCon case study).</li>
+</ul>
+<p>Modelling requirements and instructions:</p>
+<ul>
+<li>Every parameter needs to have an explicit proper prior. Improper flat priors are not allowed.</li>
+<li>A hierarchical model is a model where the prior of certain parameter contain other parameters that are also estimated in the model. For instance, <code>b ~ normal(mu, sigma)</code>, <code>mu ~ normal(0, 1)</code>, <code>sigma ~ exponential(1)</code>.</li>
+<li>Do not impose hard constrains on a parameter unless they are natural to them. <code>uniform(a, b)</code> should not be used for general parameters.</li>
+<li>Models should include covariates. Modelling the outcome without predictors is likely too simple for this analysis.</li>
+<li><code>brms</code> can be used, but the Stan code must be included, briefly commented, and all priors need to be checked from the Stan code.</li>
+</ul>
+<p>For similar notebooks we refer the student to:</p>
+<ul>
+<li>BDA R demos <a href="https://github.com/avehtari/BDA_R_demos/tree/master/demos_rstan" class="uri">https://github.com/avehtari/BDA_R_demos/tree/master/demos_rstan</a>,</li>
+<li>BDA Python demos <a href="https://github.com/avehtari/BDA_py_demos/tree/master/demos_pystan" class="uri">https://github.com/avehtari/BDA_py_demos/tree/master/demos_pystan</a>,</li>
+<li>Stan case studies <a href="http://mc-stan.org/users/documentation/case-studies.html" class="uri">http://mc-stan.org/users/documentation/case-studies.html</a>,</li>
+<li>StanCon case studies <a href="http://mc-stan.org/users/documentation/case-studies.html" class="uri">http://mc-stan.org/users/documentation/case-studies.html</a> (some of these notebooks are for a bigger projects, but reflect still the basic idea of a notebook presentation).</li>
+</ul>
 </div>
 
 


### PR DESCRIPTION
I have added the updated project work's instructions and guidelines to the web page. Can we add anything else? I left the rubric out for the moment as it felt a bit out of place.

Addresses bda_course#45 and bda_course#76.