### PR TITLE
Corrected dates and times of TA sessions

### DIFF
--- a/Aalto2020.Rmd
+++ b/Aalto2020.Rmd
@@ -69,11 +69,11 @@ Course practicalities, material, assignments, project work, peergrading, QA sess
 - There are no R/Python demos for Chapter 1
 - Make and submit [Assignment 1](assignments/assignment1.pdf). **Deadline Sunday 13.9. 23:59**
     - this assignment checks that you have sufficient prerequisite skills (basic probability calculus, and R or Python)
-	- [Rubric questions used in peergrading for Assignment 1](assignments/assignment1_rubric.html)
+        - [Rubric questions used in peergrading for Assignment 1](assignments/assignment1_rubric.html)
     - [General information about assignments](assignments.html)
-	- [R markdown template for assignments](templates/assignment_template.rmd)
-	- [FAQ for the assignments](FAQ.html) has solutions to commonly asked questions related RStudio setup, errors during package installations, etc.
-- Get help in TA sessions Wednesday 9.9. 14-16, Thursday 10.9. 12-14, or Friday 11.9. 10-12
+        - [R markdown template for assignments](templates/assignment_template.rmd)
+        - [FAQ for the assignments](FAQ.html) has solutions to commonly asked questions related RStudio setup, errors during package installations, etc.
+- Get help in TA sessions Wednesday 9.9. 12-16, Thursday 10.9. 12-14, or Friday 11.9. 12-14
     - in Oodi these are marked as exercise sessions
     - these are optional and you can choose which one to join
     - see more info about [TA sessions](assignments.html#TA_sessions)
@@ -199,7 +199,7 @@ Hierarchical models and exchangeability. BDA3 Ch 5.
 Model checking and cross-validation.
 
 - Read BDA3 Chapters 6 and 7 (skip 7.2 and 7.3)
-    - see [reading instructions for Chapter 6](chapter_notes/BDA_notes_ch6.pdf) and 
+    - see [reading instructions for Chapter 6](chapter_notes/BDA_notes_ch6.pdf) and
       [Chapter 7](chapter_notes/BDA_notes_ch7.pdf)
 - Read [Visualization in Bayesian workflow](https://doi.org/10.1111/rssa.12378)
     - more about workflow and examples of prior predictive checking and LOO-CV probability integral transformations
@@ -207,7 +207,7 @@ Model checking and cross-validation.
     - replaces BDA3 Sections 7.2 and 7.3 on cross-validation
 - Watch [Lecture 8.1](https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=7047e366-0df6-453c-867f-aafb00ca2d78) on model checking, and [Lecture 8.2](https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=d7849131-0afd-4ae6-ad64-aafb00da36f4) on cross-validation part 1. BDA3 Ch 6-7 + extra material.
 - Read [the additional comments for Chapter 6](chapter_notes/BDA_notes_ch6.pdf) and [Chapter 7](chapter_notes/BDA_notes_ch7.pdf)
-- **Q&A Monday 26.10. 14:15-16**
+- **Q&A Monday 2.11. 14:15-16**
 - Check [R demos](demos.html#BDA_R_demos) or [Python demos](demos.html#BDA_Python_demos) for Chapter 6
 - Additional reading material
     - [Model selection](https://avehtari.github.io/modelselection/)
@@ -219,7 +219,7 @@ Model checking and cross-validation.
 
 ### 9) BDA3 Ch 7, extra material, model comparison and selection
 
-PSIS-LOO, K-fold-CV, model comparison and selection. Extra lecture on variable selection with projection predictive variable selection. 
+PSIS-LOO, K-fold-CV, model comparison and selection. Extra lecture on variable selection with projection predictive variable selection.
 
 - Read Chapter 7 (no 7.2 and 7.3)
     - see [reading instructions for Chapter 7](chapter_notes/BDA_notes_ch7.pdf)
@@ -271,7 +271,7 @@ Frequency evaluation of Bayesian methods, hypothesis testing and variable select
 - Watch [Lecture 12.1](https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=e998b5dd-bf8e-42da-9f7c-ab1700ca2702) on frequency evaluation, hypothesis testing and variable selection and [Lecture 12.2](https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=c43c862a-a5a4-45da-9b27-ab1700e12012) overview of modeling data collection, BDA3 Ch 8, linear models, BDA Ch 14-18, lasso, horseshoe and Gaussian processes, BDA3 Ch 21.
 - **Q&A Monday 30.11. 14:15-16**
 - Work on project. TAs help with projects.
-- [TA sessions](assignments.html#TA_sessions) Wednesday 2.12. 14-16, Thursday 3.12. 12-14, Friday 4.12. 10-12
+- [TA sessions](assignments.html#TA_sessions) Wednesday 2.12. 14-16, Thursday 3.12. 10-14
 
 ### 13) Project evaluation
 
@@ -284,7 +284,7 @@ We strongly recommend using R in the course as there are more packages for Stan 
 - installing [RStudio Desktop](https://www.rstudio.com/products/rstudio/download/),
 - [or use RStudio remotely](FAQ.html#How_to_use_R_and_RStudio_remotely)
 
-See [FAQ](FAQ.html) for frequently asked questions about R problems in this course. The [demo codes](demos.html) provide useful starting points for all the assignments. 
+See [FAQ](FAQ.html) for frequently asked questions about R problems in this course. The [demo codes](demos.html) provide useful starting points for all the assignments.
 
 - For learning R programming basics
     - [Garrett Grolemund, Hands-On Programming with R](https://rstudio-education.github.io/hopr/)

--- a/Aalto2020.html
+++ b/Aalto2020.html
@@ -13,6 +13,7 @@
 
 <title>Bayesian Data Analysis course - Aalto 2020</title>
 
+<script src="site_libs/header-attrs-2.3/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/readable.min.css" rel="stylesheet" />
@@ -378,7 +379,7 @@ div.tocify {
 
 
 <h1 class="title toc-ignore">Bayesian Data Analysis course - Aalto 2020</h1>
-<h4 class="date">Page updated: 2020-08-24</h4>
+<h4 class="date">Page updated: 2020-08-28</h4>
 
 </div>
 
@@ -389,14 +390,11 @@ div.tocify {
 <li>There will be a course slack</li>
 </ul>
 <p>All the course material is available in a <a href="https://github.com/avehtari/BDA_course_Aalto">git repo</a> (and these pages are for easier navigation). All the material can be used in other courses. Text and videos licensed under CC-BY-NC 4.0. Code licensed under BSD-3.</p>
-<p>The material will be updated during the course. Exercise instructions and slides will be updated at latest on Monday of the corresponding week. The updated material will appear on web pages, or you can clone the repo and pull before checking new material. If you don't want to learn git, you can download the latest <a href="https://github.com/avehtari/BDA_course_Aalto/archive/master.zip">zip file</a>.</p>
+<p>The material will be updated during the course. Exercise instructions and slides will be updated at latest on Monday of the corresponding week. The updated material will appear on web pages, or you can clone the repo and pull before checking new material. If you don’t want to learn git, you can download the latest <a href="https://github.com/avehtari/BDA_course_Aalto/archive/master.zip">zip file</a>.</p>
 <div id="book-bda3" class="section level2">
 <h2>Book: BDA3</h2>
 <div style="float:right;position: relative;">
-<div class="figure">
-<img src="bda_cover.png" />
-
-</div>
+<p><img src="bda_cover.png" /></p>
 </div>
 <p><a href="https://users.aalto.fi/~ave/BDA3.pdf">The electronic version of the course book Bayesian Data Analysis, 3rd ed, by by Andrew Gelman, John Carlin, Hal Stern, David Dunson, Aki Vehtari, and Donald Rubin</a> is available for non-commercial purposes. Hard copies are available from <a href="https://www.crcpress.com/Bayesian-Data-Analysis/Gelman-Carlin-Stern-Dunson-Vehtari-Rubin/p/book/9781439840955">the publisher</a> and many book stores. Aalto library has also copies. See also <a href="http://www.stat.columbia.edu/~gelman/book/">home page for the book</a>, <a href="http://www.stat.columbia.edu/~gelman/book/errata_bda3.txt">errata for the book</a>, and <a href="chapter_notes/BDA_notes.pdf">chapter notes</a>.</p>
 </div>
@@ -405,7 +403,7 @@ div.tocify {
 <p>Primary communication channel is Slack. If you have any questions, please try to ask the course staff or other students there (active students helping others will get bonus points).</p>
 <p>Please also make sure your real name (first name + last name) is set correctly in Slack. However, if you wish to remain anonymous on Slack, it is also possible — you can simply pick a random nickname and leave your real name unspecified. However, please note that in those cases it may be more difficult for our course staff to provide help with problems you have encountered and you are not able to get <a href="assignments.html#Bonus_points">bonus points when helping others</a>.</p>
 <p>In Slack, we will have separate channels for each assignment and the project. Channel #general can be used for any kind of general discussions and questions related to the course. All important official announcements will be posted on #announcements (do not discuss on this channel). Any kind of feedback is welcome on channel #feedback. We have also got a channels #r, #python, and #stan for questions that are not specific to assignments or the project. Channel #queue is used as a queue for getting help during exercise sessions.</p>
-<p>Our lecturers and teaching assistants have names with &quot;(staff)&quot; or &quot;(TA)&quot; in the end on Slack.</p>
+<p>Our lecturers and teaching assistants have names with “(staff)” or “(TA)” in the end on Slack.</p>
 <p>If you need one-to-one help, please take part in the <a href="assignments.html#TA_sessions">TA sessions</a> and ask there</p>
 <p>If you find errors in material, post in #feedback channel in Slack or <a href="https://github.com/avehtari/BDA_course_Aalto/issues">submit an issue in github</a>.</p>
 </div>
@@ -416,7 +414,7 @@ div.tocify {
 <div id="schedule-2020" class="section level2">
 <h2>Schedule 2020</h2>
 <p>Dates for 2020 fall will be updated 17th August.</p>
-<p>The course consists of 12 blocks in periods I and II. The blocks don't match exactly specific weeks. For example, it's good start reading the material for the next block while making the assignment for one block. There are 9 assignments and a project work with presentation, and thus the assignments are not in one-to-one correspondence with the blocks. The schedule below lists the blocks and how they connect to the topics, book chapters and assignments.</p>
+<p>The course consists of 12 blocks in periods I and II. The blocks don’t match exactly specific weeks. For example, it’s good start reading the material for the next block while making the assignment for one block. There are 9 assignments and a project work with presentation, and thus the assignments are not in one-to-one correspondence with the blocks. The schedule below lists the blocks and how they connect to the topics, book chapters and assignments.</p>
 <p>Currently the video links are for the videos recorded 2019. Part of the videos will be re-recorded.</p>
 <div id="course-introduction-bda-3-ch-1-prerequisites-assignment" class="section level3">
 <h3>1) Course introduction, BDA 3 Ch 1, prerequisites assignment</h3>
@@ -437,13 +435,17 @@ div.tocify {
 <li>There are no R/Python demos for Chapter 1</li>
 <li>Make and submit <a href="assignments/assignment1.pdf">Assignment 1</a>. <strong>Deadline Sunday 13.9. 23:59</strong>
 <ul>
-<li>this assignment checks that you have sufficient prerequisite skills (basic probability calculus, and R or Python)</li>
+<li>this assignment checks that you have sufficient prerequisite skills (basic probability calculus, and R or Python)
+<ul>
 <li><a href="assignments/assignment1_rubric.html">Rubric questions used in peergrading for Assignment 1</a></li>
-<li><a href="assignments.html">General information about assignments</a></li>
+</ul></li>
+<li><a href="assignments.html">General information about assignments</a>
+<ul>
 <li><a href="templates/assignment_template.rmd">R markdown template for assignments</a></li>
 <li><a href="FAQ.html">FAQ for the assignments</a> has solutions to commonly asked questions related RStudio setup, errors during package installations, etc.</li>
 </ul></li>
-<li>Get help in TA sessions Wednesday 9.9. 14-16, Thursday 10.9. 12-14, or Friday 11.9. 10-12
+</ul></li>
+<li>Get help in TA sessions Wednesday 9.9. 12-16, Thursday 10.9. 12-14, or Friday 11.9. 12-14
 <ul>
 <li>in Oodi these are marked as exercise sessions</li>
 <li>these are optional and you can choose which one to join</li>
@@ -621,7 +623,7 @@ div.tocify {
 </ul></li>
 <li>Watch <a href="https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=7047e366-0df6-453c-867f-aafb00ca2d78">Lecture 8.1</a> on model checking, and <a href="https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=d7849131-0afd-4ae6-ad64-aafb00da36f4">Lecture 8.2</a> on cross-validation part 1. BDA3 Ch 6-7 + extra material.</li>
 <li>Read <a href="chapter_notes/BDA_notes_ch6.pdf">the additional comments for Chapter 6</a> and <a href="chapter_notes/BDA_notes_ch7.pdf">Chapter 7</a></li>
-<li><strong>Q&amp;A Monday 26.10. 14:15-16</strong></li>
+<li><strong>Q&amp;A Monday 2.11. 14:15-16</strong></li>
 <li>Check <a href="demos.html#BDA_R_demos">R demos</a> or <a href="demos.html#BDA_Python_demos">Python demos</a> for Chapter 6</li>
 <li>Additional reading material
 <ul>
@@ -705,7 +707,7 @@ div.tocify {
 <li>Watch <a href="https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=e998b5dd-bf8e-42da-9f7c-ab1700ca2702">Lecture 12.1</a> on frequency evaluation, hypothesis testing and variable selection and <a href="https://aalto.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=c43c862a-a5a4-45da-9b27-ab1700e12012">Lecture 12.2</a> overview of modeling data collection, BDA3 Ch 8, linear models, BDA Ch 14-18, lasso, horseshoe and Gaussian processes, BDA3 Ch 21.</li>
 <li><strong>Q&amp;A Monday 30.11. 14:15-16</strong></li>
 <li>Work on project. TAs help with projects.</li>
-<li><a href="assignments.html#TA_sessions">TA sessions</a> Wednesday 2.12. 14-16, Thursday 3.12. 12-14, Friday 4.12. 10-12</li>
+<li><a href="assignments.html#TA_sessions">TA sessions</a> Wednesday 2.12. 14-16, Thursday 3.12. 10-14</li>
 </ul>
 </div>
 <div id="project-evaluation" class="section level3">
@@ -735,7 +737,7 @@ div.tocify {
 </div>
 <div id="finnish-terms" class="section level2">
 <h2>Finnish terms</h2>
-<p>Sanasta &quot;bayesilainen&quot; esiintyy Suomessa muutamaa erilaista kirjoitustapaa. Muoto &quot;bayesilainen&quot; on muodostettu yleisen vieraskielisten nimien taivutussääntöjen mukaan: <em>&quot;Jos nimi on kirjoitettuna takavokaalinen mutta äännettynä etuvokaalinen, kirjoitetaan päätteseen tavallisesti takavokaali etuvokaalin sijasta, esim. Birminghamissa, Thamesilla.&quot; Terho Itkonen, Kieliopas, 6. painos, Kirjayhtymä, 1997.</em></p>
+<p>Sanasta “bayesilainen” esiintyy Suomessa muutamaa erilaista kirjoitustapaa. Muoto “bayesilainen” on muodostettu yleisen vieraskielisten nimien taivutussääntöjen mukaan: <em>“Jos nimi on kirjoitettuna takavokaalinen mutta äännettynä etuvokaalinen, kirjoitetaan päätteseen tavallisesti takavokaali etuvokaalin sijasta, esim. Birminghamissa, Thamesilla.” Terho Itkonen, Kieliopas, 6. painos, Kirjayhtymä, 1997.</em></p>
 <ul>
 <li><a href="extra_reading/sanasto.pdf">Lyhyt englanti-suomi sanasto kurssin termeistä</a></li>
 </ul>

--- a/assignments.Rmd
+++ b/assignments.Rmd
@@ -25,14 +25,14 @@ Wednesday 23:59 (peer grading period).
 - If a student receives inappropriate feedback/grading or reaction, they may "flag" it
 for TAs to check from Wednesday to Sunday (flagging period).
 Strongly conflicting feedback/gradings are also manually checked by TAs (after
-flagging period). As a guideline, the TA responsible of that particular 
+flagging period). As a guideline, the TA responsible for that particular
 assignment will resolve these flags within the next week.
 
-NOTE: The assignments instructions are still being updated and
+NOTE: The assignment instructions can be updated during the course, and
 individual assignments are not guaranteed to be up to date until Monday
-(4am) of the hand-in period of the corresponding assignment week (See
-the deadlines below, e.g. first exercise is not guaranteed to be up to
-date until 9.9 at 8am).
+8am of the hand-in period of the corresponding assignment week (See
+the deadlines below, e.g. the first assignment is not guaranteed to be up to
+date until 7.9 at 8am).
 
 Report all results in a single, anonymous *.pdf -file and submit it in
 [peergrade](https://www.peergrade.io). Submitting empty pdf or almost
@@ -108,7 +108,7 @@ the other student answers on that question are disregarded in the final
 score of the submission.
 
 There are 9 assignment rounds in total. Each round has different
-weighting when computing the total score. 
+weighting when computing the total score.
 
 ### Feedback score
 
@@ -152,7 +152,7 @@ system and be polite to your peers.
 You can get help for making assignments by asking in Slack from other
 students or in weekly TA sessions by asking TAs. The sessions are
 voluntary and one may come and go as pleases during the
-sessions. 
+sessions.
 
 There are three TA sessions each week; please see [the course
 schedule](Aalto2020.html#Schedule_2020) for more details on the meeting
@@ -164,7 +164,7 @@ You can get help in the following forms:
 - Written communication on *Slack*: you will chat with a TA using the “direct messages” feature on *Slack*. You can also e.g. share code snippets through Slack direct messages if it helps.
 - Oral communication on Zoom: you will chat with a TA using a video conference on Zoom. You can also use e.g. screen sharing on Zoom if it helps.
 
-We will use channel **#queue** in Slack to coordinate everything. We announce there when the exercise session starts. Then you will write a help request there, describing in sufficient detail exactly what is the problem with which you would need help (see below).
+We will use channel **#queue** in Slack to coordinate everything. We announce there when the TA session starts. Then you will write a help request there, describing in sufficient detail exactly what is the problem with which you would need help (see below).
 
 Once a TA is free and your question is the first request in the queue, a TA will mark it with a check mark reaction. Then the TA will contact you and help with your problem. Finally, once the problem is solved, the TA who helped you will delete your request from the queue.
 

--- a/assignments.html
+++ b/assignments.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html>
 
 <head>
 
 <meta charset="utf-8" />
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 <meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
 
@@ -14,6 +13,7 @@
 
 <title>Bayesian Data Analysis course - Assignments</title>
 
+<script src="site_libs/header-attrs-2.3/header-attrs.js"></script>
 <script src="site_libs/jquery-1.11.3/jquery.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <link href="site_libs/bootstrap-3.3.5/css/readable.min.css" rel="stylesheet" />
@@ -87,7 +87,6 @@ code {
 }
 img {
   max-width:100%;
-  height: auto;
 }
 .tabbed-pane {
   padding-top: 12px;
@@ -236,6 +235,7 @@ $(document).ready(function () {
   border: none;
   display: inline-block;
   border-radius: 4px;
+  background-color: transparent;
 }
 
 .tabset-dropdown > .nav-tabs.nav-tabs-open > li {
@@ -264,6 +264,12 @@ $(document).ready(function () {
 }
 }
 
+@media print {
+.toc-content {
+  /* see https://github.com/w3c/csswg-drafts/issues/4434 */
+  float: right;
+}
+}
 
 .toc-content {
   padding-left: 30px;
@@ -373,7 +379,7 @@ div.tocify {
 
 
 <h1 class="title toc-ignore">Bayesian Data Analysis course - Assignments</h1>
-<h4 class="date">Page updated: 2020-08-25</h4>
+<h4 class="date">Page updated: 2020-08-28</h4>
 
 </div>
 
@@ -388,9 +394,9 @@ div.tocify {
 <li>Students return their answers to <a href="https://www.peergrade.io">peergrade</a> by the end of the week (hand-in period). The deadlines are on Sundays 23:59. We can’t accept late submissions due to the peergrading process.</li>
 <li>After this, each student reviews 3 random other students’ answers and provides feedback via online rubric form in peergrade during Monday to Wednesday 23:59 (peer grading period).</li>
 <li>After peergrading, each student reflects on the feedback (reactions, e.g. not helpful/helpful) before Sunday 23:59.</li>
-<li>If a student receives inappropriate feedback/grading or reaction, they may “flag” it for TAs to check from Wednesday to Sunday (flagging period). Strongly conflicting feedback/gradings are also manually checked by TAs (after flagging period). As a guideline, the TA responsible of that particular assignment will resolve these flags within the next week.</li>
+<li>If a student receives inappropriate feedback/grading or reaction, they may “flag” it for TAs to check from Wednesday to Sunday (flagging period). Strongly conflicting feedback/gradings are also manually checked by TAs (after flagging period). As a guideline, the TA responsible for that particular assignment will resolve these flags within the next week.</li>
 </ul>
-<p>NOTE: The assignments instructions are still being updated and individual assignments are not guaranteed to be up to date until Monday (4am) of the hand-in period of the corresponding assignment week (See the deadlines below, e.g. first exercise is not guaranteed to be up to date until 9.9 at 8am).</p>
+<p>NOTE: The assignment instructions can be updated during the course, and individual assignments are not guaranteed to be up to date until Monday 8am of the hand-in period of the corresponding assignment week (See the deadlines below, e.g. the first assignment is not guaranteed to be up to date until 7.9 at 8am).</p>
 <p>Report all results in a single, anonymous *.pdf -file and submit it in <a href="https://www.peergrade.io">peergrade</a>. Submitting empty pdf or almost empty pdf is not allowed. Include also any source code to the report (either in appendix or embedded in the answer). By anonymity it is meant that the report should not contain your name or student number. In addition to the correctness of the answers, the overall quality and clearness of the report is also evaluated.</p>
 <p>The assignments are mostly solved using computer (R or Python). Related demos for each assignment are available in the course web pages (links in Materials section). See <a href="#TA_sessions">TA sessions</a> for getting help.</p>
 <p>For those who are self studying or who miss several assignment hand-ins for a good reason, there is possibility to hand-in all assignments once in January.</p>
@@ -442,7 +448,7 @@ div.tocify {
 <li>Written communication on <em>Slack</em>: you will chat with a TA using the “direct messages” feature on <em>Slack</em>. You can also e.g. share code snippets through Slack direct messages if it helps.</li>
 <li>Oral communication on Zoom: you will chat with a TA using a video conference on Zoom. You can also use e.g. screen sharing on Zoom if it helps.</li>
 </ul>
-<p>We will use channel <strong>#queue</strong> in Slack to coordinate everything. We announce there when the exercise session starts. Then you will write a help request there, describing in sufficient detail exactly what is the problem with which you would need help (see below).</p>
+<p>We will use channel <strong>#queue</strong> in Slack to coordinate everything. We announce there when the TA session starts. Then you will write a help request there, describing in sufficient detail exactly what is the problem with which you would need help (see below).</p>
 <p>Once a TA is free and your question is the first request in the queue, a TA will mark it with a check mark reaction. Then the TA will contact you and help with your problem. Finally, once the problem is solved, the TA who helped you will delete your request from the queue.</p>
 <div id="getting-help-via-slack" class="section level3">
 <h3>Getting help via Slack</h3>
@@ -473,7 +479,7 @@ div.tocify {
 <p><em>Zoom: TODO: add BDA course specific example</em></p>
 </div>
 <div id="acknowledgements" class="section level3 toc-ignore">
-<h3>Acknowledgements</h3>
+<h3 class="toc-ignore">Acknowledgements</h3>
 <p>TA session instructions above have been copied from <a href="http://ppc.cs.aalto.fi/2020/lab/">Programming Parallel Computers by Jukka Suomela</a> with CC-BY-4.0 license.</p>
 </div>
 </div>
@@ -528,7 +534,7 @@ $(document).ready(function ()  {
       theme: "bootstrap3",
       context: '.toc-content',
       hashGenerator: function (text) {
-        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_').toLowerCase();
+        return text.replace(/[.\\/?&!#<>]/g, '').replace(/\s/g, '_');
       },
       ignoreSelector: ".toc-ignore",
       scrollTo: 0

--- a/site_libs/header-attrs-2.3/header-attrs.js
+++ b/site_libs/header-attrs-2.3/header-attrs.js
@@ -1,0 +1,12 @@
+// Pandoc 2.9 adds attributes on both header and div. We remove the former (to
+// be compatible with the behavior of Pandoc < 2.8).
+document.addEventListener('DOMContentLoaded', function(e) {
+  var hs = document.querySelectorAll("div.section[class*='level'] > :first-child");
+  var i, h, a;
+  for (i = 0; i < hs.length; i++) {
+    h = hs[i];
+    if (!/^h[1-6]$/i.test(h.tagName)) continue;  // it should be a header h1-h6
+    a = h.attributes;
+    while (a.length > 0) h.removeAttribute(a[0].name);
+  }
+});

--- a/site_libs/navigation-1.1/codefolding.js
+++ b/site_libs/navigation-1.1/codefolding.js
@@ -17,13 +17,13 @@ window.initializeCodeFolding = function(show) {
   var currentIndex = 1;
 
   // select all R code blocks
-  var rCodeBlocks = $('pre.r, pre.python, pre.bash, pre.sql, pre.cpp, pre.stan, pre.julia');
+  var rCodeBlocks = $('pre.r, pre.python, pre.bash, pre.sql, pre.cpp, pre.stan, pre.julia, pre.foldable');
   rCodeBlocks.each(function() {
 
     // create a collapsable div to wrap the code in
     var div = $('<div class="collapse r-code-collapse"></div>');
-    if (show)
-      div.addClass('in');
+    show = (show || $(this).hasClass('fold-show')) && !$(this).hasClass('fold-hide');
+    if (show) div.addClass('in');
     var id = 'rcode-643E0F36' + currentIndex++;
     div.attr('id', id);
     $(this).before(div);


### PR DESCRIPTION
I updated the TA session times to match oodi/mycourses and our internal timetable. Also updated the date of the QA session in block 8, which was the same date as for block 7. I did not render the rmarkdown files, because that caused lots of changes to the html files.

Rendering the Rmd files caused some weird changes to the html files. If that's a problem, they can be rerendered before merging