### PR TITLE
Improve class-check on input

### DIFF
--- a/rpackage/R/dmvnorm.R
+++ b/rpackage/R/dmvnorm.R
@@ -19,11 +19,11 @@ dmvnorm <- function(x, mean, sigma, log = FALSE) {
 
   checkmate::assert(checkmate::checkMatrix(x),checkmate::checkVector(x))
 
-  if (class(x) == "matrix") {
+  if (inherits(x, "matrix")) {
     checkmate::assert(dim(x)[2] == length(mean),
                       .var.name = 'check that x has correct dimensions')
   }
-  else if (class(x) == "numeric") {
+  else if (inherits(x, "numeric") ) {
     checkmate::assert(length(x) == length(mean),
                       .var.name = 'check that x has correct length')
   }


### PR DESCRIPTION
This is to avoid getting error `Error in if (class(x) == "matrix") { : the condition has length > 1` when calling the function with a matrix in R 4+ e.g.:
```
abmat <- cbind(alpha, beta)
dmvnorm(abmat, mean = mu, sigma = Sigma, log = TRUE)
```
<img width="642" alt="Screen Shot 2023-03-21 at 9 22 47 AM" src="https://user-images.githubusercontent.com/163966/226733008-8058d5a7-2d88-4b0c-970c-a6cdb07f6eda.png">

