### PR TITLE
fix deploy for empty list of modified rmd files

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -31,7 +31,7 @@ jobs:
                   git checkout master
                   rmdfiles=$(git diff --name-only HEAD^ | grep '[.]*Rmd$')
                   # qmdfiles=$(git diff --name-only HEAD^ | grep '[.]*qmd$')
-                  while read -r filename; do   echo "$filename"; Rscript -e "rmarkdown::render('$filename')";   done <<< "$rmdfiles"
+                  if [ -n "${rmdfiles}" ]; then while read -r filename; do   echo "$filename"; Rscript -e "rmarkdown::render('$filename')";   done <<< "$rmdfiles"; fi
                   # while read -r filename; do   echo "$filename"; quarto render $filename;   done <<< "$qmdfiles"
 
           - name: GitHub Pages action


### PR DESCRIPTION
see example here https://github.com/mjhajharia/BDA_course_Aalto/commit/a89d6e085aef03fc2b759233ca2d6a4c7c78e753 where deploy works even if rmd files are not edited.